### PR TITLE
Support for JMS Serializer Bundle 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require": {
-		"jms/serializer-bundle": "~1.0",
+		"jms/serializer-bundle": "~1.0|~2.0",
 		"mhujer/jms-serializer-uuid": "~1.0",
 		"symfony/config": "~2.7|~3.0",
 		"symfony/dependency-injection": "~2.7|~3.0",


### PR DESCRIPTION
* https://github.com/schmittjoh/JMSSerializerBundle/releases/tag/2.0.0
* https://github.com/schmittjoh/JMSSerializerBundle/blob/master/UPGRADING.md#upgrading-from-1x-to-20

I haven't found any changes that should break this integration, also tested this and https://github.com/consistence/consistence-jms-serializer-symfony/pull/5 with the `2.0` and seemed ok.

So if you agree that there are no actions needed, could you please release a new version with this? (I'll release Consistence's repo as well).