### PR TITLE
jms/serializer 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Changelog
 
 ## 4.0.0 (2018-XX-XX)
 - [#6](../../pull/6) dropped support for PHP 7.1 as it is no longer supported
+- [#7](../../pull/7) `jms/serializer` 2.0 support
 
 ## 3.0.0 (2018-01-07)
 - [#3](https://github.com/mhujer/jms-serializer-uuid-bundle/pull/3) Added Symfony 4.0 support, dropped support for Symfony 2. Requires PHP 7.1.

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
 	],
 	"require": {
 		"php": "~7.2",
-		"jms/serializer-bundle": "~1.0 || ~2.0",
-		"mhujer/jms-serializer-uuid": "~2.0",
+		"jms/serializer-bundle": "~3.0",
+		"mhujer/jms-serializer-uuid": "~3.0",
 		"symfony/config": "~3.0 || ~4.0",
 		"symfony/dependency-injection": "~3.0 || ~4.0",
 		"symfony/http-kernel": "~3.0 || ~4.0",


### PR DESCRIPTION
Based on #5.

@simPod I'm no longer using this library and bundle in production, can you please test that it works in your application? It should be possible to install it by changing the version in `composer.json`:

```
"mhujer/jms-serializer-uuid-bundle": "dev-jms20@dev"
```

And by running `composer update mhujer/jms-serializer-uuid-bundle --with-dependencies`.

When you confirm that it works, I will tag new versions in both libraries.