### PR TITLE
Update jms/serializer-uuid-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	],
 	"require": {
 		"php": "~7.4 | ~8.0",
-		"jms/serializer-bundle": "~3.0",
+		"jms/serializer-bundle": "^4.0",
 		"mhujer/jms-serializer-uuid": "~3.0",
 		"symfony/config": "~4.4 || ~5.1",
 		"symfony/dependency-injection": "~4.4 || ~5.1",

--- a/src/DependencyInjection/MhujerJmsSerializerUuidExtension.php
+++ b/src/DependencyInjection/MhujerJmsSerializerUuidExtension.php
@@ -7,8 +7,9 @@ namespace Mhujer\JmsSerializer\Uuid\SymfonyBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class MhujerJmsSerializerUuidExtension extends \Symfony\Component\HttpKernel\DependencyInjection\Extension
+class MhujerJmsSerializerUuidExtension extends Extension
 {
 
 	private const ALIAS = 'mhujer_jms_serializer_uuid';

--- a/src/MhujerJmsSerializerUuidBundle.php
+++ b/src/MhujerJmsSerializerUuidBundle.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Mhujer\JmsSerializer\Uuid\SymfonyBundle;
 
-class MhujerJmsSerializerUuidBundle extends \Symfony\Component\HttpKernel\Bundle\Bundle
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MhujerJmsSerializerUuidBundle extends Bundle
 {
 
 }


### PR DESCRIPTION
Updates compatibility to support `jms/serializer-bundle:^4.0`

I'm running into symfony update issues while using the bundle. Seems it would require bumping the jms/serializer requirements in the serializer-uuid library too. (here https://github.com/mhujer/jms-serializer-uuid/pull/13)